### PR TITLE
Update openssl.conf to modern security standards

### DIFF
--- a/perl/openssl.conf
+++ b/perl/openssl.conf
@@ -1,91 +1,95 @@
 # OpenSSL Configuration File for ssl-admin
 
-dir				= $ENV::KEY_DIR
+dir = $ENV::KEY_DIR
 
-[ca]	
-default_ca			= CA_default
+[ ca ]
+default_ca = CA_default
 
-[CA_default]	
-serial				= $dir/prog/serial
-database			= $dir/prog/index.txt
-new_certs_dir			= $dir/active
-certificate			= $dir/active/ca.crt
-private_key			= $dir/active/ca.key
-default_days			= $ENV::KEY_DAYS
-default_crl_days		= 30
-default_md			= sha1
-preserve			= no
-email_in_dn			= yes
-nameopt				= default_ca
-certopt				= default_ca
-policy				= policy_match
+[ CA_default ]
+serial           = $dir/prog/serial
+database         = $dir/prog/index.txt
+new_certs_dir    = $dir/active
+certificate      = $dir/active/ca.crt
+private_key      = $dir/active/ca.key
+default_days     = $ENV::KEY_DAYS
+default_crl_days = 30
+default_md       = sha256
+preserve         = no
+email_in_dn      = yes
+nameopt          = default_ca
+certopt          = default_ca
+policy           = policy_match
+copy_extensions  = copy          # propagate SANs and other extensions from CSR
 
 [ policy_match ]
-countryName			= match
-stateOrProvinceName		= match
-organizationName		= match
-organizationalUnitName		= optional
-commonName			= supplied
-emailAddress			= optional
+countryName            = match
+stateOrProvinceName    = match
+organizationName       = match
+organizationalUnitName = optional
+commonName             = supplied
+emailAddress           = optional
 
-[ policy_new_ca]
-countryName			= supplied
-stateOrProvinceName		= supplied
-organizationName		= supplied
-organizationalUnitName		= optional
-commonName			= supplied
-emailAddress			= optional
-
+[ policy_new_ca ]
+countryName            = supplied
+stateOrProvinceName    = supplied
+organizationName       = supplied
+organizationalUnitName = optional
+commonName             = supplied
+emailAddress           = optional
 
 [ req ]
-default_bits			= $ENV::KEY_SIZE
-default_keyfile 		= privkey.pem
-default_md			= md5
-string_mask			= nombstr
-distinguished_name		= req_distinguished_name
-req_extensions			= v3_req
+default_bits       = $ENV::KEY_SIZE
+default_keyfile    = privkey.pem
+default_md         = sha256
+string_mask        = utf8only
+distinguished_name = req_distinguished_name
+req_extensions     = v3_req
 
 [ req_distinguished_name ]
-# Prompts
-countryName			= Country Name (2 letter code)
-countryName_min			= 2
-countryName_max			= 2
-stateOrProvinceName		= State or Province Name (full name)
-localityName			= Locality Name (eg, city)
-0.organizationName		= Organization Name (eg, company)
-organizationalUnitName		= Organizational Unit Name (eg, section)
-commonName			= Common Name (web address or username)
-commonName_max			= 64
-emailAddress			= Email Address
-emailAddress_max		= 40
+countryName                 = Country Name (2 letter code)
+countryName_min             = 2
+countryName_max             = 2
+stateOrProvinceName         = State or Province Name (full name)
+localityName                = Locality Name (eg, city)
+0.organizationName          = Organization Name (eg, company)
+organizationalUnitName      = Organizational Unit Name (eg, section)
+commonName                  = Common Name (web address or username)
+commonName_max              = 64
+emailAddress                = Email Address
+emailAddress_max            = 40
 
-# Default Variables (environment variables set from ssl-admin.pl script.
-countryName_default		= $ENV::KEY_COUNTRY
-commonName_default		= $ENV::KEY_CN
-emailAddress_default		= $ENV::KEY_EMAIL
-0.organizationName_default	= $ENV::KEY_ORG
-stateOrProvinceName_default	= $ENV::KEY_PROVINCE
-localityName_default		= $ENV::KEY_CITY
+# Defaults populated from ssl-admin config / environment
+countryName_default         = $ENV::KEY_COUNTRY
+commonName_default          = $ENV::KEY_CN
+emailAddress_default        = $ENV::KEY_EMAIL
+0.organizationName_default  = $ENV::KEY_ORG
+stateOrProvinceName_default = $ENV::KEY_PROVINCE
+localityName_default        = $ENV::KEY_CITY
 
+# Server certificate extensions
 [ server ]
+basicConstraints       = critical, CA:FALSE
+subjectKeyIdentifier   = hash
+authorityKeyIdentifier = keyid, issuer
+keyUsage               = critical, digitalSignature, keyEncipherment
+extendedKeyUsage       = serverAuth
+crlDistributionPoints  = $ENV::KEY_CRL_LOC
 
-# JY ADDED -- Make a cert with nsCertType set to "server"
-basicConstraints=CA:FALSE
-nsCertType			= server
-nsComment			= "ssl-admin (OpenSSL) Generated Server Certificate"
-subjectKeyIdentifier		= hash
-authorityKeyIdentifier		= keyid,issuer:always
-extendedKeyUsage		= serverAuth
-keyUsage 			= digitalSignature, keyEncipherment
-
+# Client certificate extensions
 [ v3_req ]
-basicConstraints 		= CA:FALSE
-keyUsage 			= keyAgreement, nonRepudiation, digitalSignature, keyEncipherment
-extendedKeyUsage		= clientAuth
-crlDistributionPoints		= $ENV::KEY_CRL_LOC
+basicConstraints       = critical, CA:FALSE
+subjectKeyIdentifier   = hash
+authorityKeyIdentifier = keyid, issuer
+keyUsage               = critical, nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage       = clientAuth
+crlDistributionPoints  = $ENV::KEY_CRL_LOC
 
+# CA certificate extensions
+# pathlen:0 limits the CA to signing end-entity certs only.
+# Remove pathlen or increase it if you intend to create intermediate CAs.
 [ v3_ca ]
-basicConstraints 		= CA:TRUE
-subjectKeyIdentifier		= hash
-authorityKeyIdentifier		= keyid:always,issuer:always
-crlDistributionPoints		= $ENV::KEY_CRL_LOC
+basicConstraints       = critical, CA:TRUE, pathlen:0
+subjectKeyIdentifier   = hash
+authorityKeyIdentifier = keyid:always, issuer:always
+keyUsage               = critical, keyCertSign, cRLSign
+crlDistributionPoints  = $ENV::KEY_CRL_LOC


### PR DESCRIPTION
## Summary

- **SHA-256 everywhere**: replaces broken `sha1` (CA) and `md5` (req) digest algorithms — both are cryptographically compromised and rejected by modern TLS stacks
- **`utf8only` string encoding**: replaces obsolete `nombstr` per RFC 5280
- **`copy_extensions = copy`**: SANs and extensions in CSRs were previously silently dropped during signing; this propagates them correctly
- **Critical constraints**: `basicConstraints` and `keyUsage` are now marked `critical` throughout — RFC 5280 requires this or validators are allowed to ignore the extensions entirely
- **CA `keyUsage`**: added `critical, keyCertSign, cRLSign` to `[v3_ca]`; CA certs must explicitly declare their signing capabilities
- **`pathlen:0`** on `[v3_ca]`: prevents unintended sub-CA chains; remove or increase if intermediate CA signing is needed
- **Removed Netscape extensions** (`nsCertType`, `nsComment`) from `[server]`: deprecated since the early 2000s, no modern software reads them
- **`crlDistributionPoints`, SKI, AKI** added to `[server]` and `[v3_req]` where they were missing
- **`authorityKeyIdentifier`** on end-entity certs no longer uses `:always` (appropriate only for CA certs)

## Test plan

- [ ] Generate a new CA cert and verify `openssl x509 -text` shows `sha256WithRSAEncryption`, critical `basicConstraints`, and `keyCertSign`/`cRLSign` key usage
- [ ] Sign a CSR that includes a SAN and confirm the SAN appears in the issued cert
- [ ] Generate a server cert and confirm `nsCertType`/`nsComment` are absent and `keyUsage` is critical
- [ ] Generate a client cert and confirm `basicConstraints` is critical
- [ ] Verify CRL generation still works after digest algorithm change

🤖 Generated with [Claude Code](https://claude.com/claude-code)