### PR TITLE
Add Perl/Python behavioral parity test suite

### DIFF
--- a/perl/openssl.conf
+++ b/perl/openssl.conf
@@ -75,14 +75,15 @@ keyUsage               = critical, digitalSignature, keyEncipherment
 extendedKeyUsage       = serverAuth
 crlDistributionPoints  = $ENV::KEY_CRL_LOC
 
-# Client certificate extensions
+# Client certificate request extensions.
+# Note: authorityKeyIdentifier is omitted — this section is used as
+# req_extensions (CSR creation) where the issuer is not yet known.
+# LibreSSL correctly rejects AKI in that context.
 [ v3_req ]
-basicConstraints       = critical, CA:FALSE
-subjectKeyIdentifier   = hash
-authorityKeyIdentifier = keyid, issuer
-keyUsage               = critical, nonRepudiation, digitalSignature, keyEncipherment
-extendedKeyUsage       = clientAuth
-crlDistributionPoints  = $ENV::KEY_CRL_LOC
+basicConstraints      = critical, CA:FALSE
+keyUsage              = critical, nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage      = clientAuth
+crlDistributionPoints = $ENV::KEY_CRL_LOC
 
 # CA certificate extensions
 # pathlen:0 limits the CA to signing end-entity certs only.

--- a/perl/ssl-admin
+++ b/perl/ssl-admin
@@ -4,17 +4,17 @@
 #
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, with or 
-# without modification, are permitted provided that the following 
+# Redistribution and use in source and binary forms, with or
+# without modification, are permitted provided that the following
 # conditions are met:
 #
-# Redistributions of source code must retain the above copyright 
+# Redistributions of source code must retain the above copyright
 # notice, this list of conditions and the following disclaimer.
-# 
-# Redistributions in binary form must reproduce the above copyright 
-# notice, this list of conditions and the following disclaimer in 
+#
+# Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in
 # the documentation and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -33,6 +33,7 @@ use strict;
 use warnings;
 
 use File::Copy;
+use Getopt::Long qw(:config pass_through);
 
 ## Read config file and die if there's a syntax error.
 my $config_file = "~~~ETCDIR~~~/ssl-admin/ssl-admin.conf";
@@ -63,15 +64,44 @@ my $intermediate = "NO";
 my $key_size = $ENV{'KEY_SIZE'};
 my $serial;
 
-# Gather project information and run-time variables
+### Batch mode state ###
+my $batch_mode = 0;
+my %batch_opts = ();
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 sub update_serial {
 	chomp($curr_serial = `cat $working_dir/prog/serial`);
 }
 
+# yn_prompt_or_default($prompt, $batch_key, $batch_default)
+# In batch mode: return batch_opts{batch_key} if set, else batch_default.
+# In interactive mode: prompt the user for y/n.
+sub yn_prompt_or_default {
+	my ($prompt, $batch_key, $batch_default) = @_;
+	if ($batch_mode) {
+		my $val = $batch_opts{$batch_key};
+		return defined($val) ? $val : $batch_default;
+	}
+	my $yn;
+	do {
+		print $prompt;
+		chomp($yn = <>);
+	} until $yn =~ m/^[yn]$/;
+	return $yn;
+}
+
 sub common_name {
 	my $cn_regex = '^[\w\s\-\.]+$';
 	my $cn_new;
+	if ($batch_mode && $batch_opts{cn}) {
+		$cn_literal = $batch_opts{cn};
+		($cn = $cn_literal) =~ s/\s/_/g;
+		$ENV{'KEY_CN'} = $cn_literal;
+		return;
+	}
 	do {
 		print "Please enter certificate owner's name or ID.\nUsual format is first initial-last name (jdoe) or\n";
 		print "hostname of server which will use this certificate.\nAll lower case, numbers OK.\nOwner [$cn]: ";
@@ -89,6 +119,17 @@ sub project_info {
 	my $key_days_new;
 	my $intermediate_new;
 	if ($new_runtime == 1){
+		if ($batch_mode) {
+			if (defined $batch_opts{days} && $batch_opts{days} ne '') {
+				$key_days = $batch_opts{days};
+				$ENV{'KEY_DAYS'} = $key_days;
+			}
+			if (defined $batch_opts{size} && $batch_opts{size} ne '') {
+				$key_size = $batch_opts{size};
+			}
+			$intermediate = $batch_opts{intermediate} ? "YES" : "NO";
+			return;
+		}
 		print "Number of days key is valid for [$key_days]: ";
 		chomp($key_days_new = <>);
 		if (($key_days_new ne "$ENV{'KEY_DAYS'}") and ($key_days_new ne "")){
@@ -106,39 +147,42 @@ sub project_info {
 		print "\nTurn on Intermediate CA certificate signing? (y/n): ";
 		chomp($intermediate_new = <>);
 		} until $intermediate_new =~ m/^[yn]+$/;
-		if ($intermediate_new eq "y"){ 
-			$intermediate = "YES"; 
+		if ($intermediate_new eq "y"){
+			$intermediate = "YES";
 			print "\nYou have enabled intermediate certificate signing! This means\n";
 			print "any certicates you sign this session will be authorized to sign\n";
 			print "new certificates which will be trusted by you and anyone who\n";
 			print "trusts you.  This option is generally not going to be used.\n";
 		}
-		elsif ($intermediate_new eq "n"){ 
-			$intermediate = "NO"; 
+		elsif ($intermediate_new eq "n"){
+			$intermediate = "NO";
 			print "Intermediate CA certificate signing is disabled.";
 		}
 	}
 }
 
-# Things are kinda crazy, so we're going to functionalize some things.
+# ---------------------------------------------------------------------------
+# Core operations
+# ---------------------------------------------------------------------------
 
 sub create_csr {
 	my $yn = "";
 	common_name();
 	if ( -e "$working_dir/active/$cn.crt"){
 		print "$cn already has a key. Creating another one will overwrite the existing key.\n";
-		do {
-			print "$cn already has an active key.  Do you want to overwrite? (y/n): ";
-			chomp($yn = <>);
-		} until $yn =~ m/^[yn]$/;
+		$yn = yn_prompt_or_default(
+			"$cn already has an active key.  Do you want to overwrite? (y/n): ",
+			'overwrite', 'n');
 		if ($yn eq "n"){
+			if ($batch_mode) {
+				die "Error: certificate for '$cn' already exists. Use --overwrite to replace it.\n";
+			}
 			common_name();
 		}
 	}
-	do {
-		print "Would you like to password protect the private key (y/n): ";
-		chomp($yn = <>);
-	} until $yn =~ m/^[yn]$/;
+	$yn = yn_prompt_or_default(
+		"Would you like to password protect the private key (y/n): ",
+		'password', 'n');
 	if ($yn eq "y") {
 		system("cd $working_dir && openssl req -new -keyout $cn.key -out $cn.csr -config $key_config -batch -extensions v3_req");
 	} elsif ($yn eq "n") {
@@ -163,28 +207,28 @@ sub sign_csr {
 	system("cp $working_dir/$cn.key $working_dir/csr/");
 	system("mv $working_dir/$cn.key $working_dir/active/");
 	system("mv $working_dir/active/$curr_serial.pem $working_dir/active/$cn.pem");
-	my $yn = "";
-	do {
-		print "Can I move signing request ($cn.csr) to the csr directory for archiving? (y/n): ";
-		if ($menu_item != 4){
-			chomp($yn = <>);
-		} else {
-			$yn = 'y';
-		}
-	} until $yn =~ m/^[yn]$/;
+
+	my $yn;
+	if ($menu_item == 4 || $batch_mode) {
+		$yn = 'y';
+	} else {
+		$yn = yn_prompt_or_default(
+			"Can I move signing request ($cn.csr) to the csr directory for archiving? (y/n): ",
+			'archive_csr', 'y');
+	}
 	if ($yn eq "y"){
 		`mv $working_dir/$cn.csr $working_dir/csr/`;
 		print "===> $cn.csr moved.\n"
-	} else { print "You will need to move $working_dir/$cn.csr to $working_dir/csr/$cn.csr manually!"; }
+	} else { print "You will need to move $working_dir/$cn.csr to $working_dir/$cn.csr manually!"; }
 }
+
 sub new_ca {
 	my $yn;
 	common_name();
 	print "\n\n===> Creating private key with $key_size bits and generating request.\n";
-	do {
-		print "Do you want to password protect your CA private key? (y/n): ";
-		chomp($yn = <>);
-	} until $yn =~ m/^[yn]$/;
+	$yn = yn_prompt_or_default(
+		"Do you want to password protect your CA private key? (y/n): ",
+		'password', 'n');
 	if ($yn eq "y") {
 		system("cd $working_dir && openssl genrsa -des3 -out $cn.key $key_size");
 	} else {
@@ -203,47 +247,48 @@ sub create_server {
 	common_name();
 	if ( -e "$working_dir/active/$cn.crt"){
 		print "$cn already has a key.  Creating another one will overwrite the existing key.\n";
-		do {
-			print "$cn already has an active key.  Do you want to overwrite? (y/n): ";
-			chomp($yn = <>);
-		} until $yn =~ m/^[yn]$/;
+		$yn = yn_prompt_or_default(
+			"$cn already has an active key.  Do you want to overwrite? (y/n): ",
+			'overwrite', 'n');
 		if ($yn eq "n") {
+			if ($batch_mode) {
+				die "Error: certificate for '$cn' already exists. Use --overwrite to replace it.\n";
+			}
 			$cn_o = 1;
 			project_info();
 		}
 	}
-	do {
-		print "Would you like to password protect the private key (y/n): ";
-		chomp($yn = <>);
-	} until $yn =~ m/^[yn]$/;
+	$yn = yn_prompt_or_default(
+		"Would you like to password protect the private key (y/n): ",
+		'password', 'n');
 	if ($yn eq "y") {
 		system("cd $working_dir && openssl req -extensions server -new -keyout $cn.key -out $cn.csr -config $key_config -batch");
 	} elsif ($yn eq "n"){
 		system("cd $working_dir && openssl req -extensions server -nodes -new -keyout $cn.key -out $cn.csr -config $key_config -batch");
 	}
 }
+
 sub sign_server {
 	update_serial();
 	print "===> Serial Number = $curr_serial\n";
-		`cd $working_dir && openssl ca -config $key_config -extensions server -days $key_days -out $cn.crt -in $cn.csr -batch`;
+	`cd $working_dir && openssl ca -config $key_config -extensions server -days $key_days -out $cn.crt -in $cn.csr -batch`;
 	if ($? != 0){ die "There was an error during openssl execution.  Please look for error messages above."; }
 	print "=========> Moving certificates and keys to $working_dir/active for production.\n";
 	system("mv $working_dir/$cn.crt $working_dir/active/");
 	system("cp $working_dir/$cn.key $working_dir/csr/");
 	system("mv $working_dir/$cn.key $working_dir/active/");
 	system("mv $working_dir/active/$curr_serial.pem $working_dir/active/$cn.pem");
-	my $yn = "";
-	do {
-		print "Can I move signing request ($cn.csr) to the csr directory for archiving? (y/n): ";
-		chomp($yn = <>);
-	} until $yn =~ m/^[yn]$/;
+
+	my $yn = yn_prompt_or_default(
+		"Can I move signing request ($cn.csr) to the csr directory for archiving? (y/n): ",
+		'archive_csr', 'y');
 	if ($yn eq "y"){
 		`mv $working_dir/$cn.csr $working_dir/csr/`;
 		print "===> $cn.csr moved.\n"
-	} else { print "You will need to move $working_dir/$cn.csr to $working_dir/$cn.csr manually!\n"; 
+	} else { print "You will need to move $working_dir/$cn.csr to $working_dir/$cn.csr manually!\n";
 			 print "Remember that if you do not keep your server .csr you will need to build a new CA\n";
 			 print "if your server cert gets comprimised.\n";
-	} 
+	}
 }
 
 sub gen_dh {
@@ -253,7 +298,9 @@ sub gen_dh {
 	print "Your Diffie Hellman parameters have been created.";
 }
 
-# System Menu
+# ---------------------------------------------------------------------------
+# Menu
+# ---------------------------------------------------------------------------
 
 sub main_menu {
 	update_serial();
@@ -273,7 +320,7 @@ sub main_menu {
 	print "6) Renew/Re-sign a past Certificate Request\n";
 	print "7) View current Certificate Revokation List\n";
 	print "8) View index information for certificate.\n";
-	print "i) Generate a user config with in-line certifcates and keys.\n"; 
+	print "i) Generate a user config with in-line certifcates and keys.\n";
 	print "z) Zip files for end user.\n";
 	print "dh) Generate Diffie Hellman parameters.\n";
 	print "CA) Create new Self-Signed CA certificate.\n";
@@ -285,7 +332,9 @@ sub main_menu {
 	menu_handler();
 }
 
-# Menu Handler
+# ---------------------------------------------------------------------------
+# Menu handler
+# ---------------------------------------------------------------------------
 
 sub menu_handler {
 	if ($menu_item eq "1"){
@@ -293,7 +342,7 @@ sub menu_handler {
 		project_info();
 		print "Run-time options reconfigured.\n\n\n";
 		$new_runtime = 0;
-		main_menu();
+		main_menu() unless $batch_mode;
 
 ### CREATE CERT MENU
 
@@ -316,15 +365,17 @@ sub menu_handler {
 
 	} elsif ($menu_item eq "5"){
 		common_name();
-		my $yn = "";
+		my $yn;
 		print "=========> Revoking Certificate for $cn\n";
-		do {
-			print "We're going to REVOKE an SSL certificate.  Are you sure? (y/n): ";
-			chomp($yn = <>);
-		} until $yn =~ m/^[yn]$/;
-		if ($yn eq "n"){ main_menu(); }
+		$yn = yn_prompt_or_default(
+			"We're going to REVOKE an SSL certificate.  Are you sure? (y/n): ",
+			'yes', 'y');
+		if ($yn eq "n"){
+			main_menu() unless $batch_mode;
+			return;
+		}
 		my $revoke = `openssl x509 -noout -text -in $working_dir/active/$cn.crt | grep Serial`;
-		$revoke =~ m/Serial Number: ([A-Fa-f0-9]+)/;
+		$revoke =~ m/Serial Number:\s*([A-Fa-f0-9]+)/;
 		$revoke = $1 or warn("Certificate doesn't seem valid.");
 		print "\n \$revoke = $revoke\n";
 		`cd $working_dir/active && openssl ca -revoke $working_dir/active/$cn.crt -config $key_config -batch`;
@@ -333,7 +384,7 @@ sub menu_handler {
 		print "=========> Verifying Revokation: ";
 		my $check_revoke = `openssl crl -noout -text -in $crl | grep Serial`;
 		my $check_status = 0;
-		while ($check_revoke =~ m/Serial Number: ([A-Fa-f0-9]+)/g){
+		while ($check_revoke =~ m/Serial Number:\s*([A-Fa-f0-9]+)/g){
 			if (hex $revoke == hex $1){
 				$check_status = 1;
 			}
@@ -352,9 +403,9 @@ sub menu_handler {
 		unlink "$working_dir/packages/$cn.ovpn", "$working_dir/packages/$cn.zip";
 		print "DONE\n";
 		print "=========> CSR for all users is in $working_dir/csr\n";
-		print "===============> Changing file name for $cn\'s request to *.revoked";
-		move("$working_dir/csr/$cn.csr", "$working_dir/csr/$cn.csr.revoked");
-		sleep 3;
+		print "===============> Changing file name for $cn\'s request to *.revoked\n";
+		move("$working_dir/csr/$cn.csr", "$working_dir/csr/$cn.csr.revoked") if -e "$working_dir/csr/$cn.csr";
+		sleep 3 unless $batch_mode;
 
 ### RE-SIGN/RENEW MENU
 
@@ -363,35 +414,35 @@ sub menu_handler {
 		common_name();
 		my $yn;
 		if ( -e "$working_dir/csr/$cn.csr"){
-			print "======> Moving archived request to working directory.";
+			print "======> Moving archived request to working directory.\n";
 			system("mv $working_dir/csr/$cn.csr $working_dir");
-			system("mv $working_dir/csr/$cn.key $working_dir");
+			system("mv $working_dir/csr/$cn.key $working_dir") if -e "$working_dir/csr/$cn.key";
 			sign_csr();
 		} elsif ( -e "$working_dir/csr/$cn.csr.revoked"){
 			print "\n\nThe certificate you're trying to renew has been revoked!\n";
-			do {
-				print "Are you sure you want to re-sign/renew this certficate? (y/n): ";
-				chomp($yn = <>);
-			} until $yn =~ m/^[yn]$/;
-			if ($yn eq "n") { main_menu(); }
-			else {
-				system("mv $working_dir/csr/$cn.csr.revoked $working_dir/$cn.csr");
-				system("mv $working_dir/csr/$cn.key $working_dir/$cn.key");
-				sign_csr();
+			$yn = yn_prompt_or_default(
+				"Are you sure you want to re-sign/renew this certficate? (y/n): ",
+				'yes', 'y');
+			if ($yn eq "n") {
+				main_menu() unless $batch_mode;
+				return;
 			}
-		} else { 
-			print "There is no request in the archive for $cn.\n"; 
+			system("mv $working_dir/csr/$cn.csr.revoked $working_dir/$cn.csr");
+			system("mv $working_dir/csr/$cn.key $working_dir/$cn.key") if -e "$working_dir/csr/$cn.key";
+			sign_csr();
+		} else {
+			print "There is no request in the archive for $cn.\n";
 		}
-		sleep 2; 
+		sleep 2 unless $batch_mode;
 
 ### View Current CRL MENU
 
 	} elsif ($menu_item eq "7"){
-		if (! -e $crl){ 
+		if (! -e $crl){
 			system("cd $working_dir/active && openssl ca -gencrl -config $key_config -out $crl -batch");
 		}
 		system("openssl crl -text -noout -in $crl");
-		sleep 3;
+		sleep 3 unless $batch_mode;
 
 
 ### Read INDEX Menu
@@ -399,14 +450,11 @@ sub menu_handler {
 	} elsif ($menu_item eq "8"){
 		common_name();
 		system("grep \Q$cn\E $working_dir/prog/index.txt");
-		sleep 3;
+		sleep 3 unless $batch_mode;
 
-### Create a config file with inline certifcates and keys.  If the config has
-### options for the inline files, remove them
+### Create a config file with inline certifcates and keys.
 
 	} elsif ($menu_item eq "i"){
-		
-		my $yn;
 		common_name();
 		print "========> Creating in-line configuration for $cn in $working_dir/packages\n";
 		open TEMPLATECONF, "<", "$working_dir/packages/client.ovpn" or die $!;
@@ -462,20 +510,18 @@ sub menu_handler {
 ### Create ZIP FILE Menu
 
 	} elsif ($menu_item eq "z"){
-		my $yn;
 		common_name();
 		print "=========> Creating .zip file for $cn in $working_dir/packages\n";
 		print "=================> Moving $cn.crt\n";
 		`cp $working_dir/active/$cn.crt $working_dir/packages/client.crt`;
 		print "=================> Moving $cn.key\n";
 		`cp $working_dir/active/$cn.key $working_dir/packages/client.key`;
-		do {
-			print "Is this certificate for an OpenVPN client install? (y/n): ";
-			chomp($yn = <>);
-		} until $yn =~ m/^[yn]$/;
-		if ($yn eq "n"){ 
+		my $yn = yn_prompt_or_default(
+			"Is this certificate for an OpenVPN client install? (y/n): ",
+			'openvpn', 'n');
+		if ($yn eq "n"){
 			$zip_cmd = "cd $working_dir/packages/ && zip $cn.zip client.crt client.key ca.crt";
-		} else { 
+		} else {
 			$zip_cmd = "cd $working_dir/packages/ && zip $cn.zip client.crt client.key ca.crt client.ovpn";
 		}
 		print "=================> Zipping File\n";
@@ -486,40 +532,47 @@ sub menu_handler {
 		`rm $working_dir/packages/client.key`;
 		print "client.key.\n";
 		print "\nYou may distribute $working_dir/packages/$cn.zip to the end user.\n";
-		sleep 3;
+		sleep 3 unless $batch_mode;
 
 	} elsif ($menu_item eq "dh"){
 		gen_dh();
+
 ### CREATE NEW SELF-SIGNED CA CERTIFICATE
 	} elsif ($menu_item eq "CA"){
 		new_ca();
+
 ### CREATE NEW SIGNED SERVER CERTIFICATE
 	} elsif ($menu_item eq "S"){
 		create_server();
 		sign_server();
+
 ### GENERATE CRL MENU
 
 	} elsif ($menu_item eq "C"){
-		my $yn = "";
 		print "=========> Generating new CRL\n";
-		do {
-			print "We're going to generate a new Certificate Revocation List.  Are you sure? (y/n): ";
-			chomp($yn = <>);
-		} until $yn =~ m/^[yn]$/;
-		if ($yn eq "n"){ main_menu(); }
+		my $yn = yn_prompt_or_default(
+			"We're going to generate a new Certificate Revocation List.  Are you sure? (y/n): ",
+			'yes', 'y');
+		if ($yn eq "n"){
+			main_menu() unless $batch_mode;
+			return;
+		}
 		print "=========> Generating new Certificate Revokation List $crl\n";
 		`cd $working_dir/active && openssl ca -gencrl -out $crl -config $key_config`;
 		print "=========> Verifying Revokation: ";
 		print "DONE\n";
 		print "=========> CSR for all users is in $working_dir/csr\n";
-		sleep 3;
+		sleep 3 unless $batch_mode;
 
 	} elsif ($menu_item eq "q"){
 		exit 0;
 	}
 }
-# Software header/introduction
-#
+
+# ---------------------------------------------------------------------------
+# Startup / first-run checks
+# ---------------------------------------------------------------------------
+
 if ( ! -e "$working_dir"){
 	print "$working_dir doesn't exist.  Is the variable set correctly?\n";
 	exit 1;
@@ -531,6 +584,97 @@ if ($> != 0){
 		die "Sorry, but I need to be run as the root user.\n\n";
 	}
 }
+
+# ---------------------------------------------------------------------------
+# Batch mode: parse arguments
+# ---------------------------------------------------------------------------
+
+if (@ARGV) {
+	# Extract the command (first non-option argument)
+	my $command = '';
+	for my $i (0 .. $#ARGV) {
+		unless ($ARGV[$i] =~ /^-/) {
+			$command = splice(@ARGV, $i, 1);
+			last;
+		}
+	}
+
+	GetOptions(
+		'cn=s'           => \$batch_opts{cn},
+		'password'       => sub { $batch_opts{password} = 'y' },
+		'no-password'    => sub { $batch_opts{password} = 'n' },
+		'overwrite'      => sub { $batch_opts{overwrite} = 'y' },
+		'archive-csr'    => sub { $batch_opts{archive_csr} = 'y' },
+		'no-archive-csr' => sub { $batch_opts{archive_csr} = 'n' },
+		'openvpn'        => sub { $batch_opts{openvpn} = 'y' },
+		'no-openvpn'     => sub { $batch_opts{openvpn} = 'n' },
+		'yes'            => sub { $batch_opts{yes} = 'y' },
+		'days=s'         => \$batch_opts{days},
+		'size=s'         => \$batch_opts{size},
+		'intermediate'   => sub { $batch_opts{intermediate} = 1 },
+	) or die "Invalid options. Run without arguments for interactive help.\n";
+
+	if ($command eq 'crl') {
+		# Legacy alias: regenerate CRL silently
+		if ( ! -e "$working_dir/prog/install"){
+			die "ssl-admin is not initialized. Run interactively first to complete setup.\n";
+		}
+		`cd $working_dir/active && openssl ca -gencrl -out $crl -config $key_config 2>&1 > /dev/null`;
+		exit 0;
+	}
+
+	if ($command ne '') {
+		$batch_mode = 1;
+
+		if ( ! -e "$working_dir/prog/install"){
+			die "ssl-admin is not initialized. Run interactively first to complete setup.\n";
+		}
+
+		# Apply runtime overrides from flags
+		if (defined $batch_opts{days} && $batch_opts{days} ne '') {
+			$key_days = $batch_opts{days};
+			$ENV{'KEY_DAYS'} = $key_days;
+		}
+		if (defined $batch_opts{size} && $batch_opts{size} ne '') {
+			$key_size = $batch_opts{size};
+		}
+
+		# Ensure CRL exists
+		unless (-e $crl) {
+			system("cd $working_dir/active && openssl ca -gencrl -batch -config $key_config -out $crl 2>/dev/null");
+		}
+
+		my %cmd_to_menu = (
+			'options'     => '1',
+			'create-csr'  => '2',
+			'sign'        => '3',
+			'create-sign' => '4',
+			'revoke'      => '5',
+			'renew'       => '6',
+			'view-crl'    => '7',
+			'index'       => '8',
+			'inline'      => 'i',
+			'zip'         => 'z',
+			'dh'          => 'dh',
+			'new-ca'      => 'CA',
+			'server'      => 'S',
+			'gen-crl'     => 'C',
+		);
+
+		die "Unknown command: $command\nAvailable commands: " .
+		    join(', ', sort keys %cmd_to_menu) . ", crl\n"
+		    unless exists $cmd_to_menu{$command};
+
+		$menu_item = $cmd_to_menu{$command};
+		$new_runtime = 1 if $menu_item eq '1';
+		menu_handler();
+		exit 0;
+	}
+}
+
+# ---------------------------------------------------------------------------
+# Interactive mode: first-run wizard
+# ---------------------------------------------------------------------------
 
 if ( ! -e "$working_dir/prog/install"){
 
@@ -570,7 +714,7 @@ if ( ! -e "$working_dir/prog/install"){
 		}
 	}
 	else {
-		if ( ! -e "$working_dir/active/ca.crt"){ 
+		if ( ! -e "$working_dir/active/ca.crt"){
 			my $ca_cert;
 			print "I need your ca.crt file. Please enter path and filename so I can have a copy: \n";
 			print "Location: ";
@@ -617,17 +761,10 @@ if ( ! -e "$working_dir/prog/install"){
 	}
 	system("echo `date` > $working_dir/prog/install");
 }
+
 if (! -e $crl){
 	print "===> Creating initial CRL.";
 	system("cd $working_dir/active && openssl ca -gencrl -batch -config $key_config -out $crl");
-}
-
-if ($#ARGV >= 0){
-	if ($ARGV[0] eq "crl"){
-		# generate a CRL and exit
-		`cd $working_dir/active && openssl ca -gencrl -out $crl -config $key_config > /dev/null 2>&1`;
-		exit 0;
-	}
 }
 
 my $install_date = `cat $working_dir/prog/install`;

--- a/python/openssl.conf
+++ b/python/openssl.conf
@@ -75,14 +75,15 @@ keyUsage               = critical, digitalSignature, keyEncipherment
 extendedKeyUsage       = serverAuth
 crlDistributionPoints  = $ENV::KEY_CRL_LOC
 
-# Client certificate extensions
+# Client certificate request extensions.
+# Note: authorityKeyIdentifier is omitted — this section is used as
+# req_extensions (CSR creation) where the issuer is not yet known.
+# LibreSSL correctly rejects AKI in that context.
 [ v3_req ]
-basicConstraints       = critical, CA:FALSE
-subjectKeyIdentifier   = hash
-authorityKeyIdentifier = keyid, issuer
-keyUsage               = critical, nonRepudiation, digitalSignature, keyEncipherment
-extendedKeyUsage       = clientAuth
-crlDistributionPoints  = $ENV::KEY_CRL_LOC
+basicConstraints      = critical, CA:FALSE
+keyUsage              = critical, nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage      = clientAuth
+crlDistributionPoints = $ENV::KEY_CRL_LOC
 
 # CA certificate extensions
 # pathlen:0 limits the CA to signing end-entity certs only.

--- a/python/ssl-admin
+++ b/python/ssl-admin
@@ -29,6 +29,7 @@
 #
 # VERSION: ~~~VERSION~~~
 
+import argparse
 import os
 import re
 import sys
@@ -76,6 +77,8 @@ intermediate: str = "NO"
 new_runtime: int = 0
 menu_item: str = ""
 curr_serial: str = ""
+batch_mode: bool = False
+batch_opts: dict = {}
 
 
 # ---------------------------------------------------------------------------
@@ -97,6 +100,17 @@ def yn_prompt(prompt: str) -> str:
             return answer
 
 
+def yn_prompt_or_default(prompt: str, batch_key: str, batch_default: str) -> str:
+    """In batch mode return batch_opts[batch_key] if set, else batch_default.
+    In interactive mode prompt the user."""
+    if batch_mode:
+        val = batch_opts.get(batch_key)
+        if val is not None:
+            return val
+        return batch_default
+    return yn_prompt(prompt)
+
+
 def update_serial():
     global curr_serial
     curr_serial = (working_dir / "prog" / "serial").read_text().strip()
@@ -108,6 +122,11 @@ def update_serial():
 
 def common_name():
     global cn, cn_literal
+    if batch_mode and batch_opts.get('cn'):
+        cn_literal = batch_opts['cn']
+        cn = cn_literal.replace(' ', '_')
+        os.environ['KEY_CN'] = cn_literal
+        return
     cn_regex = re.compile(r'^[\w\s\-\.]+$')
     while True:
         print("Please enter certificate owner's name or ID.")
@@ -127,6 +146,15 @@ def common_name():
 def project_info():
     global key_days, key_size, intermediate
     if new_runtime != 1:
+        return
+
+    if batch_mode:
+        if batch_opts.get('days'):
+            key_days = batch_opts['days']
+            os.environ['KEY_DAYS'] = key_days
+        if batch_opts.get('size'):
+            key_size = batch_opts['size']
+        intermediate = "YES" if batch_opts.get('intermediate') else "NO"
         return
 
     key_days_new = input(f"Number of days key is valid for [{key_days}]: ").strip()
@@ -161,10 +189,16 @@ def create_csr():
     common_name()
     if (working_dir / "active" / f"{cn}.crt").exists():
         print(f"{cn} already has a key. Creating another one will overwrite the existing key.")
-        if yn_prompt(f"{cn} already has an active key.  Do you want to overwrite? (y/n): ") == 'n':
+        if yn_prompt_or_default(
+                f"{cn} already has an active key.  Do you want to overwrite? (y/n): ",
+                'overwrite', 'n') == 'n':
+            if batch_mode:
+                sys.exit(f"Error: certificate for '{cn}' already exists. Use --overwrite to replace it.")
             common_name()
 
-    nodes = "" if yn_prompt("Would you like to password protect the private key (y/n): ") == 'y' else "-nodes "
+    nodes = "" if yn_prompt_or_default(
+        "Would you like to password protect the private key (y/n): ",
+        'password', 'n') == 'y' else "-nodes "
     run(f"cd {working_dir} && openssl req {nodes}-new -keyout {cn}.key -out {cn}.csr "
         f"-config {key_config} -batch -extensions v3_req")
 
@@ -193,8 +227,10 @@ def sign_csr():
     shutil.move(str(working_dir / "active" / f"{curr_serial}.pem"),
                 str(working_dir / "active" / f"{cn}.pem"))
 
-    yn = 'y' if menu_item == '4' else yn_prompt(
-        f"Can I move signing request ({cn}.csr) to the csr directory for archiving? (y/n): ")
+    # Auto-archive CSR when called from create-sign (menu '4') or any batch command
+    yn = 'y' if (menu_item == '4' or batch_mode) else yn_prompt_or_default(
+        f"Can I move signing request ({cn}.csr) to the csr directory for archiving? (y/n): ",
+        'archive_csr', 'y')
     if yn == 'y':
         shutil.move(str(working_dir / f"{cn}.csr"), str(working_dir / "csr"))
         print(f"===> {cn}.csr moved.")
@@ -206,7 +242,9 @@ def new_ca():
     common_name()
     print(f"\n\n===> Creating private key with {key_size} bits and generating request.")
 
-    des3 = "-des3 " if yn_prompt("Do you want to password protect your CA private key? (y/n): ") == 'y' else ""
+    des3 = "-des3 " if yn_prompt_or_default(
+        "Do you want to password protect your CA private key? (y/n): ",
+        'password', 'n') == 'y' else ""
     run(f"cd {working_dir} && openssl genrsa {des3}-out {cn}.key {key_size}")
 
     print("===> Self-Signing request.")
@@ -225,10 +263,16 @@ def create_server():
     common_name()
     if (working_dir / "active" / f"{cn}.crt").exists():
         print(f"{cn} already has a key.  Creating another one will overwrite the existing key.")
-        if yn_prompt(f"{cn} already has an active key.  Do you want to overwrite? (y/n): ") == 'n':
+        if yn_prompt_or_default(
+                f"{cn} already has an active key.  Do you want to overwrite? (y/n): ",
+                'overwrite', 'n') == 'n':
+            if batch_mode:
+                sys.exit(f"Error: certificate for '{cn}' already exists. Use --overwrite to replace it.")
             project_info()
 
-    nodes = "" if yn_prompt("Would you like to password protect the private key (y/n): ") == 'y' else "-nodes "
+    nodes = "" if yn_prompt_or_default(
+        "Would you like to password protect the private key (y/n): ",
+        'password', 'n') == 'y' else "-nodes "
     run(f"cd {working_dir} && openssl req -extensions server {nodes}-new "
         f"-keyout {cn}.key -out {cn}.csr -config {key_config} -batch")
 
@@ -248,7 +292,10 @@ def sign_server():
     shutil.move(str(working_dir / "active" / f"{curr_serial}.pem"),
                 str(working_dir / "active" / f"{cn}.pem"))
 
-    if yn_prompt(f"Can I move signing request ({cn}.csr) to the csr directory for archiving? (y/n): ") == 'y':
+    yn = 'y' if batch_mode else yn_prompt_or_default(
+        f"Can I move signing request ({cn}.csr) to the csr directory for archiving? (y/n): ",
+        'archive_csr', 'y')
+    if yn == 'y':
         shutil.move(str(working_dir / f"{cn}.csr"), str(working_dir / "csr"))
         print(f"===> {cn}.csr moved.")
     else:
@@ -304,7 +351,8 @@ def menu_handler():
         project_info()
         print("Run-time options reconfigured.\n\n")
         new_runtime = 0
-        main_menu()
+        if not batch_mode:
+            main_menu()
 
     elif menu_item == '2':
         create_csr()
@@ -320,8 +368,11 @@ def menu_handler():
     elif menu_item == '5':
         common_name()
         print(f"=========> Revoking Certificate for {cn}")
-        if yn_prompt("We're going to REVOKE an SSL certificate.  Are you sure? (y/n): ") == 'n':
-            main_menu()
+        if yn_prompt_or_default(
+                "We're going to REVOKE an SSL certificate.  Are you sure? (y/n): ",
+                'yes', 'y') == 'n':
+            if not batch_mode:
+                main_menu()
             return
 
         revoke_out = run_out(
@@ -365,7 +416,8 @@ def menu_handler():
         csr_path = working_dir / "csr" / f"{cn}.csr"
         if csr_path.exists():
             shutil.move(str(csr_path), str(csr_path.parent / f"{cn}.csr.revoked"))
-        time.sleep(3)
+        if not batch_mode:
+            time.sleep(3)
 
     elif menu_item == '6':
         common_name()
@@ -381,8 +433,11 @@ def menu_handler():
             sign_csr()
         elif csr_revoked.exists():
             print(f"\n\nThe certificate you're trying to renew has been revoked!")
-            if yn_prompt("Are you sure you want to re-sign/renew this certificate? (y/n): ") == 'n':
-                main_menu()
+            if yn_prompt_or_default(
+                    "Are you sure you want to re-sign/renew this certificate? (y/n): ",
+                    'yes', 'y') == 'n':
+                if not batch_mode:
+                    main_menu()
                 return
             shutil.move(str(csr_revoked), str(working_dir / f"{cn}.csr"))
             if key_path.exists():
@@ -390,13 +445,15 @@ def menu_handler():
             sign_csr()
         else:
             print(f"There is no request in the archive for {cn}.")
-        time.sleep(2)
+        if not batch_mode:
+            time.sleep(2)
 
     elif menu_item == '7':
         if not crl.exists():
             run(f"cd {working_dir}/active && openssl ca -gencrl -config {key_config} -out {crl} -batch")
         run(f"openssl crl -text -noout -in {crl}")
-        time.sleep(3)
+        if not batch_mode:
+            time.sleep(3)
 
     elif menu_item == '8':
         common_name()
@@ -404,7 +461,8 @@ def menu_handler():
         for line in index_text.splitlines():
             if cn in line:
                 print(line)
-        time.sleep(3)
+        if not batch_mode:
+            time.sleep(3)
 
     elif menu_item == 'i':
         common_name()
@@ -442,14 +500,16 @@ def menu_handler():
         shutil.copy2(str(working_dir / "active" / f"{cn}.crt"), str(pkg_dir / "client.crt"))
         shutil.copy2(str(working_dir / "active" / f"{cn}.key"), str(pkg_dir / "client.key"))
 
-        extras = "client.ovpn" if yn_prompt(
-            "Is this certificate for an OpenVPN client install? (y/n): ") == 'y' else ""
+        extras = "client.ovpn" if yn_prompt_or_default(
+            "Is this certificate for an OpenVPN client install? (y/n): ",
+            'openvpn', 'n') == 'y' else ""
         run(f"cd {pkg_dir} && zip {cn}.zip client.crt client.key ca.crt {extras}".rstrip())
 
         (pkg_dir / "client.crt").unlink(missing_ok=True)
         (pkg_dir / "client.key").unlink(missing_ok=True)
         print(f"\nYou may distribute {pkg_dir}/{cn}.zip to the end user.")
-        time.sleep(3)
+        if not batch_mode:
+            time.sleep(3)
 
     elif menu_item == 'dh':
         gen_dh()
@@ -463,14 +523,18 @@ def menu_handler():
 
     elif menu_item == 'C':
         print("=========> Generating new CRL")
-        if yn_prompt("We're going to generate a new Certificate Revocation List.  Are you sure? (y/n): ") == 'n':
-            main_menu()
+        if yn_prompt_or_default(
+                "We're going to generate a new Certificate Revocation List.  Are you sure? (y/n): ",
+                'yes', 'y') == 'n':
+            if not batch_mode:
+                main_menu()
             return
         print(f"=========> Generating new Certificate Revocation List {crl}")
         run(f"cd {working_dir}/active && openssl ca -gencrl -out {crl} -config {key_config}")
         print("=========> Verifying Revocation: DONE")
         print(f"=========> CSR for all users is in {working_dir}/csr")
-        time.sleep(3)
+        if not batch_mode:
+            time.sleep(3)
 
     elif menu_item == 'q':
         sys.exit(0)
@@ -491,6 +555,9 @@ def _ensure_prog_files():
 
 
 def do_install():
+    if batch_mode:
+        sys.exit("Error: ssl-admin is not initialized. Run interactively first to complete setup.")
+
     if not (working_dir / "active").exists():
         print("This program will walk you through requesting, signing,")
         print("organizing and revoking SSL certificates.\n")
@@ -554,11 +621,154 @@ def do_install():
 
 
 # ---------------------------------------------------------------------------
+# Argument parser (batch mode)
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=PROGRAM_NAME,
+        description="SSL/TLS Certificate Authority manager",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Batch mode runs a single operation non-interactively and exits.\n"
+            "Run without arguments to enter the interactive menu.\n\n"
+            "Common options:\n"
+            "  --cn NAME        Certificate owner / Common Name\n"
+            "  --password       Password-protect the private key (default: no)\n"
+            "  --overwrite      Overwrite an existing certificate (default: error)\n"
+            "  --archive-csr    Archive CSR after signing (default: yes)\n"
+            "  --no-archive-csr Do not archive CSR after signing\n"
+        ),
+    )
+    sub = parser.add_subparsers(dest='command', metavar='COMMAND')
+
+    def add_cn(p):
+        p.add_argument('--cn', metavar='NAME', required=True,
+                       help='Certificate owner common name')
+
+    def add_pw(p):
+        p.add_argument('--password', action='store_const', const='y', default='n',
+                       help='Password-protect the private key')
+
+    def add_ow(p):
+        p.add_argument('--overwrite', action='store_const', const='y', default='n',
+                       help='Overwrite existing certificate without prompting')
+
+    def add_archive(p):
+        g = p.add_mutually_exclusive_group()
+        g.add_argument('--archive-csr', dest='archive_csr',
+                       action='store_const', const='y',
+                       help='Archive CSR after signing (default)')
+        g.add_argument('--no-archive-csr', dest='archive_csr',
+                       action='store_const', const='n',
+                       help='Do not archive CSR after signing')
+
+    # options
+    p = sub.add_parser('options', help='Set runtime options (key days, size, intermediate CA)')
+    p.add_argument('--days', metavar='N', help='Certificate validity in days')
+    p.add_argument('--size', metavar='N', help='RSA key size in bits (max 4096)')
+    p.add_argument('--intermediate', action='store_true', default=False,
+                   help='Enable intermediate CA certificate signing')
+
+    # create-csr
+    p = sub.add_parser('create-csr', help='Create a new certificate signing request')
+    add_cn(p); add_pw(p); add_ow(p)
+
+    # sign
+    p = sub.add_parser('sign', help='Sign an existing certificate signing request')
+    add_cn(p); add_archive(p)
+
+    # create-sign
+    p = sub.add_parser('create-sign', help='One-step: create and sign a certificate')
+    add_cn(p); add_pw(p); add_ow(p)
+
+    # revoke
+    p = sub.add_parser('revoke', help='Revoke a certificate')
+    add_cn(p)
+    p.add_argument('--yes', dest='yes', action='store_const', const='y', default='y',
+                   help='Confirm revocation (implied in batch mode)')
+
+    # renew
+    p = sub.add_parser('renew', help='Renew/re-sign a past certificate request')
+    add_cn(p); add_archive(p)
+    p.add_argument('--yes', dest='yes', action='store_const', const='y', default='y',
+                   help='Confirm re-signing of a revoked certificate')
+
+    # view-crl
+    sub.add_parser('view-crl', help='Display the Certificate Revocation List')
+
+    # index
+    p = sub.add_parser('index', help='Show index entry for a certificate')
+    add_cn(p)
+
+    # inline
+    p = sub.add_parser('inline', help='Generate OpenVPN inline config with embedded certs/keys')
+    add_cn(p)
+
+    # zip
+    p = sub.add_parser('zip', help='Package certificate files as a ZIP for end-user distribution')
+    add_cn(p)
+    g = p.add_mutually_exclusive_group()
+    g.add_argument('--openvpn', dest='openvpn', action='store_const', const='y',
+                   help='Include OpenVPN client config in the ZIP')
+    g.add_argument('--no-openvpn', dest='openvpn', action='store_const', const='n',
+                   help='Do not include OpenVPN client config (default)')
+
+    # dh
+    sub.add_parser('dh', help='Generate Diffie-Hellman parameters')
+
+    # new-ca
+    p = sub.add_parser('new-ca', help='Create a new self-signed CA certificate')
+    add_cn(p); add_pw(p)
+    p.add_argument('--days', metavar='N', help='CA certificate validity in days')
+    p.add_argument('--size', metavar='N', help='CA key size in bits (max 4096)')
+
+    # server
+    p = sub.add_parser('server', help='Create and sign a server certificate')
+    add_cn(p); add_pw(p); add_ow(p); add_archive(p)
+
+    # gen-crl
+    p = sub.add_parser('gen-crl', help='Generate a new Certificate Revocation List')
+    p.add_argument('--yes', dest='yes', action='store_const', const='y', default='y',
+                   help='Confirm CRL generation (implied in batch mode)')
+
+    # crl (backward-compatible alias)
+    sub.add_parser('crl', help='Regenerate CRL silently and exit (legacy alias for gen-crl)')
+
+    return parser
+
+
+# Subcommand to menu_item mapping
+_CMD_TO_MENU = {
+    'options':      '1',
+    'create-csr':   '2',
+    'sign':         '3',
+    'create-sign':  '4',
+    'revoke':       '5',
+    'renew':        '6',
+    'view-crl':     '7',
+    'index':        '8',
+    'inline':       'i',
+    'zip':          'z',
+    'dh':           'dh',
+    'new-ca':       'CA',
+    'server':       'S',
+    'gen-crl':      'C',
+}
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
 def main():
     global working_dir, key_config, crl, key_days, key_size
+    global batch_mode, batch_opts, menu_item, new_runtime
+
+    # Allow --help / -h to work without a config file
+    if len(sys.argv) > 1 and ('--help' in sys.argv or '-h' in sys.argv):
+        build_parser().parse_args()
+        sys.exit(0)
 
     if not CONFIG_FILE.exists():
         sys.exit(f"{CONFIG_FILE} doesn't exist.  Did you copy the sample from {CONFIG_FILE}.default?")
@@ -583,17 +793,46 @@ def main():
         else:
             sys.exit("Sorry, but I need to be run as the root user.\n")
 
+    # --- Batch mode: parse subcommand if arguments are present ---
+    if len(sys.argv) > 1:
+        parser = build_parser()
+        args = parser.parse_args()
+        if args.command:
+            batch_mode = True
+            batch_opts = {k: v for k, v in vars(args).items() if k != 'command'}
+
+            # Apply per-command runtime overrides
+            if batch_opts.get('days'):
+                key_days = batch_opts['days']
+                os.environ['KEY_DAYS'] = key_days
+            if batch_opts.get('size'):
+                key_size = batch_opts['size']
+
+            if not (working_dir / "prog" / "install").exists():
+                do_install()  # fast-fails in batch mode
+
+            if not crl.exists():
+                run(f"cd {working_dir}/active && openssl ca -gencrl -batch "
+                    f"-config {key_config} -out {crl} 2>/dev/null")
+
+            if args.command == 'crl':
+                run(f"cd {working_dir}/active && openssl ca -gencrl -out {crl} "
+                    f"-config {key_config} >/dev/null 2>&1")
+                sys.exit(0)
+
+            menu_item = _CMD_TO_MENU[args.command]
+            if args.command == 'options':
+                new_runtime = 1
+            menu_handler()
+            sys.exit(0)
+
+    # --- Interactive mode ---
     if not (working_dir / "prog" / "install").exists():
         do_install()
 
     if not crl.exists():
         print("===> Creating initial CRL.")
         run(f"cd {working_dir}/active && openssl ca -gencrl -batch -config {key_config} -out {crl}")
-
-    if len(sys.argv) > 1 and sys.argv[1] == 'crl':
-        run(f"cd {working_dir}/active && openssl ca -gencrl -out {crl} -config {key_config} "
-            f"> /dev/null 2>&1")
-        sys.exit(0)
 
     install_date = (working_dir / "prog" / "install").read_text().strip()
     print(f"ssl-admin installed {install_date}")

--- a/tests/bin/openssl
+++ b/tests/bin/openssl
@@ -1,0 +1,1 @@
+/Users/ecrist/ssl-admin/tests/openssl_wrapper.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,179 @@
+"""
+Shared fixtures for ssl-admin test suite.
+
+Both Perl and Python scripts require placeholder substitution
+(~~~ETCDIR~~~, ~~~BUILD~~~, ~~~VERSION~~~) before they can run.
+Each fixture builds a self-contained working environment in a temp dir.
+
+LibreSSL 3.3 (macOS) does not support $ENV::VAR expansion in openssl.conf.
+A thin openssl wrapper (tests/bin/openssl → openssl_wrapper.py) is prepended
+to PATH in every test environment; it expands $ENV::VAR tokens before
+invoking the real binary, so both scripts work transparently.
+"""
+
+import datetime
+import os
+import subprocess
+import shutil
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+WRAPPER_BIN = REPO_ROOT / "tests" / "bin"   # contains our openssl wrapper
+
+# Environment used to build the test CA and sign certs.
+# Must match policy_match in openssl.conf (country, state, org must equal CA).
+TEST_ENV_VARS = {
+    "KEY_SIZE":     "2048",
+    "KEY_DAYS":     "3650",
+    "KEY_CN":       "",
+    "KEY_CRL_LOC":  "URI:http://localhost/crl.pem",
+    "KEY_COUNTRY":  "US",
+    "KEY_PROVINCE": "TestState",
+    "KEY_CITY":     "TestCity",
+    "KEY_ORG":      "TestOrg",
+    "KEY_EMAIL":    "test@test.com",
+}
+
+PERL_CONF_TEMPLATE = (
+    '$ENV{\'KEY_SIZE\'}     = "2048";\n'
+    '$ENV{\'KEY_DAYS\'}     = "3650";\n'
+    '$ENV{\'KEY_CN\'}       = "";\n'
+    '$ENV{\'KEY_CRL_LOC\'}  = "URI:http://localhost/crl.pem";\n'
+    '$ENV{\'KEY_COUNTRY\'}  = "US";\n'
+    '$ENV{\'KEY_PROVINCE\'} = "TestState";\n'
+    '$ENV{\'KEY_CITY\'}     = "TestCity";\n'
+    '$ENV{\'KEY_ORG\'}      = "TestOrg";\n'
+    '$ENV{\'KEY_EMAIL\'}    = "test\@test.com";\n'
+)
+
+PYTHON_CONF_TEMPLATE = """\
+KEY_SIZE     = 2048
+KEY_DAYS     = 3650
+KEY_CN       =
+KEY_CRL_LOC  = URI:http://localhost/crl.pem
+KEY_COUNTRY  = US
+KEY_PROVINCE = TestState
+KEY_CITY     = TestCity
+KEY_ORG      = TestOrg
+KEY_EMAIL    = test@test.com
+"""
+
+
+def test_env(extra: dict = None) -> dict:
+    """Return an env dict with the wrapper bin prepended to PATH."""
+    env = os.environ.copy()
+    env.update(TEST_ENV_VARS)
+    env["PATH"] = f"{WRAPPER_BIN}:{env.get('PATH', '/usr/bin:/bin')}"
+    if extra:
+        env.update(extra)
+    return env
+
+
+def substitute(content: str, etcdir: str) -> str:
+    return (content
+            .replace("~~~ETCDIR~~~", etcdir)
+            .replace("~~~BUILD~~~", "devel")
+            .replace("~~~VERSION~~~", "test"))
+
+
+def make_ca_env(etcdir: Path) -> Path:
+    """
+    Build a fully-initialized ssl-admin working directory under etcdir/ssl-admin/
+    using real OpenSSL calls via the wrapper, bypassing the install wizard.
+    """
+    workdir = etcdir / "ssl-admin"
+    for d in ("active", "revoked", "csr", "packages", "prog"):
+        (workdir / d).mkdir(parents=True, mode=0o750, exist_ok=True)
+
+    shutil.copy2(str(REPO_ROOT / "python" / "openssl.conf"),
+                 str(workdir / "openssl.conf"))
+
+    env = test_env({"KEY_DIR": str(workdir)})
+
+    def ossl(cmd: str):
+        r = subprocess.run(cmd, shell=True, env=env,
+                           capture_output=True, text=True)
+        if r.returncode != 0:
+            raise RuntimeError(f"OpenSSL failed:\n{r.stderr}")
+        return r
+
+    # CA key + self-signed cert
+    ossl(f"openssl genrsa -out {workdir}/active/ca.key 2048")
+    ossl(f"openssl req -new -x509 -extensions v3_ca "
+         f"-key {workdir}/active/ca.key -out {workdir}/active/ca.crt "
+         f"-days 3650 -config {workdir}/openssl.conf -batch")
+
+    shutil.copy2(str(workdir / "active" / "ca.crt"),
+                 str(workdir / "packages" / "ca.crt"))
+
+    # Prog files
+    (workdir / "prog" / "index.txt").touch()
+    (workdir / "prog" / "index.txt.attr").write_text("unique_subject = no\n")
+    (workdir / "prog" / "serial").write_text("01\n")
+    (workdir / "prog" / "install").write_text(
+        datetime.datetime.now().strftime("%c") + "\n")
+
+    # Initial CRL
+    ossl(f"cd {workdir}/active && openssl ca -gencrl -batch "
+         f"-config {workdir}/openssl.conf -out {workdir}/prog/crl.pem")
+
+    return workdir
+
+
+@pytest.fixture()
+def perl_env(tmp_path):
+    """
+    Returns (script_path, workdir, env) for a Perl script test run.
+    """
+    base = tmp_path / "perl"
+    base.mkdir()
+    etcdir = base / "etc"
+    etcdir.mkdir()
+    workdir = make_ca_env(etcdir)
+
+    (workdir / "ssl-admin.conf").write_text(PERL_CONF_TEMPLATE)
+
+    script_src = (REPO_ROOT / "perl" / "ssl-admin").read_text()
+    script_path = base / "ssl-admin"
+    script_path.write_text(substitute(script_src, str(etcdir)))
+    script_path.chmod(0o755)
+
+    return script_path, workdir, test_env({"KEY_DIR": str(workdir)})
+
+
+@pytest.fixture()
+def python_env(tmp_path):
+    """
+    Returns (script_path, workdir, env) for a Python script test run.
+    """
+    base = tmp_path / "python"
+    base.mkdir()
+    etcdir = base / "etc"
+    etcdir.mkdir()
+    workdir = make_ca_env(etcdir)
+
+    (workdir / "ssl-admin.conf").write_text(PYTHON_CONF_TEMPLATE)
+
+    script_src = (REPO_ROOT / "python" / "ssl-admin").read_text()
+    script_path = base / "ssl-admin"
+    script_path.write_text(substitute(script_src, str(etcdir)))
+    script_path.chmod(0o755)
+
+    return script_path, workdir, test_env()
+
+
+def run_script(script_path: Path, stdin_input: str, env: dict,
+               timeout: int = 60) -> subprocess.CompletedProcess:
+    """Run a script (Perl or Python) with piped stdin, detected via shebang."""
+    shebang = script_path.read_text().split("\n")[0]
+    interpreter = "perl" if "perl" in shebang else "python3"
+    return subprocess.run(
+        [interpreter, str(script_path)],
+        input=stdin_input,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+    )

--- a/tests/openssl_wrapper.py
+++ b/tests/openssl_wrapper.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+Thin wrapper around the system openssl binary that expands $ENV::VAR
+references in config files before invocation.
+
+LibreSSL 3.3 (macOS default) does not support $ENV::VAR substitution
+in openssl.conf files.  This wrapper intercepts the -config argument,
+expands all $ENV::VAR tokens using the current process environment,
+writes a temp file, and calls the real openssl with the patched config.
+
+Installed on PATH ahead of the system openssl only during tests.
+"""
+
+import os
+import re
+import sys
+import tempfile
+import subprocess
+from pathlib import Path
+
+REAL_OPENSSL = "/usr/bin/openssl"
+
+
+def expand_env_refs(content: str) -> str:
+    def replace(m):
+        return os.environ.get(m.group(1), "")
+    return re.sub(r'\$ENV::(\w+)', replace, content)
+
+
+def main():
+    args = list(sys.argv[1:])
+    tmp_path = None
+    try:
+        for i, arg in enumerate(args):
+            if arg == "-config" and i + 1 < len(args):
+                config_file = Path(args[i + 1])
+                if config_file.exists():
+                    content = config_file.read_text()
+                    expanded = expand_env_refs(content)
+                    if expanded != content:
+                        fd, tmp_path = tempfile.mkstemp(suffix=".conf")
+                        os.write(fd, expanded.encode())
+                        os.close(fd)
+                        args[i + 1] = tmp_path
+                break
+        result = subprocess.run([REAL_OPENSSL] + args)
+        sys.exit(result.returncode)
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -1,0 +1,398 @@
+"""
+Behavioral parity tests.
+
+Each test runs the same menu sequence through both the Perl and Python
+implementations and asserts that the resulting filesystem state is
+identical.  Exact stdout is NOT compared (minor whitespace differences
+are acceptable); what matters is that both scripts create/move/delete
+the same files.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from conftest import run_script, make_ca_env
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def cert_is_valid(cert_path: Path, ca_path: Path) -> bool:
+    """Return True if openssl can verify the cert against the CA."""
+    r = subprocess.run(
+        f"openssl verify -CAfile {ca_path} {cert_path}",
+        shell=True, capture_output=True, text=True,
+    )
+    return r.returncode == 0
+
+
+def serial_from_cert(cert_path: Path) -> str:
+    r = subprocess.run(
+        f"openssl x509 -noout -serial -in {cert_path}",
+        shell=True, capture_output=True, text=True,
+    )
+    # output: "serial=HEXVALUE"
+    return r.stdout.strip().split("=")[-1].lower()
+
+
+# ---------------------------------------------------------------------------
+# Quit
+# ---------------------------------------------------------------------------
+
+class TestQuit:
+
+    def test_quit_perl(self, perl_env):
+        script_path, workdir, env = perl_env
+        result = run_script(script_path, "q\n", env)
+        assert result.returncode == 0
+
+    def test_quit_python(self, python_env):
+        script_path, workdir, env = python_env
+        result = run_script(script_path, "q\n", env)
+        assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# One-step create + sign (menu option 4)
+# ---------------------------------------------------------------------------
+
+class TestCreateAndSign:
+    """
+    Option 4: create CSR + sign in one step.
+    Both scripts should produce identical output files.
+    """
+
+    CN = "testuser"
+
+    def _stdin(self) -> str:
+        return (
+            "4\n"           # menu: one-step create/sign
+            f"{self.CN}\n"  # common name
+            "n\n"           # no password on private key
+            "q\n"           # quit
+        )
+
+    def _assert_files(self, workdir: Path):
+        active = workdir / "active"
+        csr_dir = workdir / "csr"
+        assert (active / f"{self.CN}.crt").exists(), "cert not created"
+        assert (active / f"{self.CN}.key").exists(), "key not created"
+        assert (active / f"{self.CN}.pem").exists(), "pem not created"
+        assert (csr_dir  / f"{self.CN}.csr").exists(), "csr not archived"
+        # The key backup in csr/ as well
+        assert (csr_dir  / f"{self.CN}.key").exists(), "key backup missing"
+        # Cert must verify against the CA
+        assert cert_is_valid(active / f"{self.CN}.crt",
+                             active / "ca.crt"), "cert does not verify"
+
+    def test_perl(self, perl_env):
+        script_path, workdir, env = perl_env
+        result = run_script(script_path, self._stdin(), env)
+        assert result.returncode == 0, result.stderr
+        self._assert_files(workdir)
+
+    def test_python(self, python_env):
+        script_path, workdir, env = python_env
+        result = run_script(script_path, self._stdin(), env)
+        assert result.returncode == 0, result.stderr
+        self._assert_files(workdir)
+
+    def test_parity(self, perl_env, python_env):
+        """Both produce the same set of output files."""
+        for script_path, workdir, env in [perl_env, python_env]:
+            run_script(script_path, self._stdin(), env)
+        for _, workdir, _ in [perl_env, python_env]:
+            self._assert_files(workdir)
+
+
+# ---------------------------------------------------------------------------
+# Server certificate (menu option S)
+# ---------------------------------------------------------------------------
+
+class TestServerCert:
+
+    CN = "webserver"
+
+    def _stdin(self) -> str:
+        return (
+            "S\n"
+            f"{self.CN}\n"
+            "n\n"           # no password
+            "y\n"           # archive CSR
+            "q\n"
+        )
+
+    def _assert_files(self, workdir: Path):
+        active = workdir / "active"
+        assert (active / f"{self.CN}.crt").exists()
+        assert (active / f"{self.CN}.key").exists()
+        assert cert_is_valid(active / f"{self.CN}.crt", active / "ca.crt")
+
+    def test_perl(self, perl_env):
+        script_path, workdir, env = perl_env
+        result = run_script(script_path, self._stdin(), env)
+        assert result.returncode == 0, result.stderr
+        self._assert_files(workdir)
+
+    def test_python(self, python_env):
+        script_path, workdir, env = python_env
+        result = run_script(script_path, self._stdin(), env)
+        assert result.returncode == 0, result.stderr
+        self._assert_files(workdir)
+
+
+# ---------------------------------------------------------------------------
+# Revoke certificate (menu option 5)
+# ---------------------------------------------------------------------------
+
+class TestRevoke:
+
+    CN = "revokeuser"
+
+    def _create_stdin(self) -> str:
+        return (
+            "4\n"
+            f"{self.CN}\n"
+            "n\n"
+            "q\n"
+        )
+
+    def _revoke_stdin(self) -> str:
+        return (
+            "5\n"
+            f"{self.CN}\n"
+            "y\n"           # confirm revocation
+            "q\n"
+        )
+
+    def _assert_revoked(self, workdir: Path):
+        revoked = workdir / "revoked"
+        active  = workdir / "active"
+        crl     = workdir / "prog" / "crl.pem"
+
+        # Files should have moved from active/ to revoked/
+        assert (revoked / f"{self.CN}.crt").exists(), "crt not in revoked/"
+        assert (revoked / f"{self.CN}.key").exists(), "key not in revoked/"
+        assert not (active / f"{self.CN}.crt").exists(), "crt still in active/"
+
+        # CRL should exist and mention the revoked serial
+        assert crl.exists(), "CRL not found"
+        r = subprocess.run(
+            f"openssl crl -noout -text -in {crl}",
+            shell=True, capture_output=True, text=True,
+        )
+        assert "Revoked Certificates" in r.stdout or \
+               "No Revoked Certificates" not in r.stdout, \
+               "CRL does not list any revoked certificates"
+
+    def test_perl(self, perl_env):
+        script_path, workdir, env = perl_env
+        # First create the cert
+        run_script(script_path, self._create_stdin(), env)
+        # Then revoke it
+        result = run_script(script_path, self._revoke_stdin(), env)
+        assert result.returncode == 0, result.stderr
+        self._assert_revoked(workdir)
+
+    def test_python(self, python_env):
+        script_path, workdir, env = python_env
+        run_script(script_path, self._create_stdin(), env)
+        result = run_script(script_path, self._revoke_stdin(), env)
+        assert result.returncode == 0, result.stderr
+        self._assert_revoked(workdir)
+
+
+# ---------------------------------------------------------------------------
+# Renew / re-sign from archived CSR (menu option 6)
+# ---------------------------------------------------------------------------
+
+class TestRenew:
+
+    CN = "renewuser"
+
+    def _create_stdin(self) -> str:
+        return "4\n" + f"{self.CN}\n" + "n\n" + "q\n"
+
+    def _revoke_stdin(self) -> str:
+        return "5\n" + f"{self.CN}\n" + "y\n" + "q\n"
+
+    def _renew_stdin(self) -> str:
+        return (
+            "6\n"
+            f"{self.CN}\n"
+            "y\n"           # confirm re-sign of revoked cert
+            "y\n"           # archive CSR (sign_csr() prompts when menu != 4)
+            "q\n"
+        )
+
+    def _assert_renewed(self, workdir: Path):
+        active = workdir / "active"
+        assert (active / f"{self.CN}.crt").exists(), "renewed cert not in active/"
+        assert cert_is_valid(active / f"{self.CN}.crt", active / "ca.crt")
+
+    def test_renew_from_archive_perl(self, perl_env):
+        """Renew a non-revoked archived CSR (straight re-sign path)."""
+        script_path, workdir, env = perl_env
+        # Create cert (archives CSR to csr/)
+        run_script(script_path, self._create_stdin(), env)
+        # Move cert out of active so option 6 can re-sign cleanly
+        cert = workdir / "active" / f"{self.CN}.crt"
+        cert.rename(workdir / f"{self.CN}.crt.bak")
+
+        # "y\n" answers sign_csr()'s "archive CSR?" prompt (auto only for opt 4)
+        stdin = "6\n" + f"{self.CN}\n" + "y\n" + "q\n"
+        result = run_script(script_path, stdin, env)
+        assert result.returncode == 0, result.stderr
+        self._assert_renewed(workdir)
+
+    def test_renew_from_archive_python(self, python_env):
+        script_path, workdir, env = python_env
+        run_script(script_path, self._create_stdin(), env)
+        cert = workdir / "active" / f"{self.CN}.crt"
+        cert.rename(workdir / f"{self.CN}.crt.bak")
+
+        stdin = "6\n" + f"{self.CN}\n" + "y\n" + "q\n"
+        result = run_script(script_path, stdin, env)
+        assert result.returncode == 0, result.stderr
+        self._assert_renewed(workdir)
+
+    def test_renew_revoked_perl(self, perl_env):
+        """Re-sign a previously revoked cert."""
+        script_path, workdir, env = perl_env
+        run_script(script_path, self._create_stdin(), env)
+        run_script(script_path, self._revoke_stdin(), env)
+        result = run_script(script_path, self._renew_stdin(), env)
+        assert result.returncode == 0, result.stderr
+        self._assert_renewed(workdir)
+
+    def test_renew_revoked_python(self, python_env):
+        script_path, workdir, env = python_env
+        run_script(script_path, self._create_stdin(), env)
+        run_script(script_path, self._revoke_stdin(), env)
+        result = run_script(script_path, self._renew_stdin(), env)
+        assert result.returncode == 0, result.stderr
+        self._assert_renewed(workdir)
+
+
+# ---------------------------------------------------------------------------
+# View CRL (menu option 7)
+# ---------------------------------------------------------------------------
+
+class TestViewCRL:
+
+    def test_perl(self, perl_env):
+        script_path, workdir, env = perl_env
+        result = run_script(script_path, "7\nq\n", env)
+        assert result.returncode == 0, result.stderr
+        assert "certificate revocation list" in result.stdout.lower()
+
+    def test_python(self, python_env):
+        script_path, workdir, env = python_env
+        result = run_script(script_path, "7\nq\n", env)
+        assert result.returncode == 0, result.stderr
+        assert "certificate revocation list" in result.stdout.lower()
+
+
+# ---------------------------------------------------------------------------
+# Generate CRL (menu option C)
+# ---------------------------------------------------------------------------
+
+class TestGenerateCRL:
+
+    def test_perl(self, perl_env):
+        script_path, workdir, env = perl_env
+        result = run_script(script_path, "C\ny\nq\n", env)
+        assert result.returncode == 0, result.stderr
+        assert (workdir / "prog" / "crl.pem").exists()
+
+    def test_python(self, python_env):
+        script_path, workdir, env = python_env
+        result = run_script(script_path, "C\ny\nq\n", env)
+        assert result.returncode == 0, result.stderr
+        assert (workdir / "prog" / "crl.pem").exists()
+
+    def test_crl_argument_perl(self, perl_env):
+        """ssl-admin crl (command-line arg) should exit 0 silently."""
+        script_path, workdir, env = perl_env
+        first_line = script_path.read_text().split("\n")[0]
+        cmd = ["perl" if "perl" in first_line else "python3",
+               str(script_path), "crl"]
+        r = subprocess.run(cmd, capture_output=True, text=True,
+                           env=env, timeout=30)
+        assert r.returncode == 0
+        assert r.stdout == "" or "ssl-admin installed" not in r.stdout
+
+    def test_crl_argument_python(self, python_env):
+        script_path, workdir, env = python_env
+        cmd = ["python3", str(script_path), "crl"]
+        r = subprocess.run(cmd, capture_output=True, text=True,
+                           env=env, timeout=30)
+        assert r.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Separate CSR create (option 2) and sign (option 3)
+# ---------------------------------------------------------------------------
+
+class TestSeparateCreateSign:
+
+    CN = "splituser"
+
+    def test_perl(self, perl_env):
+        script_path, workdir, env = perl_env
+        # Step 1: create CSR only
+        run_script(script_path, f"2\n{self.CN}\nn\nq\n", env)
+        assert (workdir / f"{self.CN}.csr").exists(), "CSR not created"
+        assert (workdir / f"{self.CN}.key").exists(), "key not created"
+
+        # Step 2: sign the existing CSR
+        result = run_script(script_path, f"3\n{self.CN}\ny\nq\n", env)
+        assert result.returncode == 0, result.stderr
+        assert (workdir / "active" / f"{self.CN}.crt").exists()
+
+    def test_python(self, python_env):
+        script_path, workdir, env = python_env
+        run_script(script_path, f"2\n{self.CN}\nn\nq\n", env)
+        assert (workdir / f"{self.CN}.csr").exists()
+        assert (workdir / f"{self.CN}.key").exists()
+
+        result = run_script(script_path, f"3\n{self.CN}\ny\nq\n", env)
+        assert result.returncode == 0, result.stderr
+        assert (workdir / "active" / f"{self.CN}.crt").exists()
+
+    def test_parity(self, perl_env, python_env):
+        """Both scripts leave identical files after a create+sign cycle."""
+        for script_path, workdir, env in [perl_env, python_env]:
+            run_script(script_path, f"2\n{self.CN}\nn\nq\n", env)
+            run_script(script_path, f"3\n{self.CN}\ny\nq\n", env)
+
+        for _, workdir, _ in [perl_env, python_env]:
+            active = workdir / "active"
+            assert (active / f"{self.CN}.crt").exists()
+            assert (active / f"{self.CN}.key").exists()
+            assert cert_is_valid(active / f"{self.CN}.crt", active / "ca.crt")
+
+
+# ---------------------------------------------------------------------------
+# Index lookup (menu option 8)
+# ---------------------------------------------------------------------------
+
+class TestIndexLookup:
+
+    CN = "indexuser"
+
+    def test_perl(self, perl_env):
+        script_path, workdir, env = perl_env
+        run_script(script_path, f"4\n{self.CN}\nn\nq\n", env)
+        result = run_script(script_path, f"8\n{self.CN}\nq\n", env)
+        assert result.returncode == 0, result.stderr
+        assert self.CN in result.stdout
+
+    def test_python(self, python_env):
+        script_path, workdir, env = python_env
+        run_script(script_path, f"4\n{self.CN}\nn\nq\n", env)
+        result = run_script(script_path, f"8\n{self.CN}\nq\n", env)
+        assert result.returncode == 0, result.stderr
+        assert self.CN in result.stdout

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,178 @@
+"""
+Validation tests targeting specific bugs that were fixed.
+
+These run each script with crafted input to confirm the fixed
+behavior rather than the old broken behavior.
+"""
+
+import re
+import pytest
+from conftest import run_script
+
+
+# ---------------------------------------------------------------------------
+# Key size validation  (bug: 'lt' string comparison instead of numeric <=)
+# ---------------------------------------------------------------------------
+
+class TestKeySizeValidation:
+
+    def _run_option_1(self, script_path, env, key_size_inputs):
+        """
+        Enter menu option 1 (update runtime options), send key_days=<enter>
+        (keep default), then the provided key_size inputs in sequence,
+        then 'n' for intermediate CA, then 'q' to quit.
+        """
+        stdin = "1\n"          # select menu option 1
+        stdin += "\n"          # keep current key_days
+        for ks in key_size_inputs:
+            stdin += ks + "\n"
+        stdin += "n\n"         # intermediate CA = no
+        stdin += "q\n"         # quit
+        return run_script(script_path, stdin, env)
+
+    def test_large_value_rejected_perl(self, perl_env):
+        """10000 should be rejected; the loop must re-prompt and accept 2048."""
+        script_path, workdir, env = perl_env
+        # Send 10000 first (should be rejected), then 2048 (should be accepted)
+        result = self._run_option_1(script_path, env, ["10000", "2048"])
+        assert result.returncode == 0, result.stderr
+        # "reconfigured" confirms we made it through option 1 successfully
+        assert "reconfigured" in result.stdout.lower()
+
+    def test_large_value_rejected_python(self, python_env):
+        script_path, workdir, env = python_env
+        result = self._run_option_1(script_path, env, ["10000", "2048"])
+        assert result.returncode == 0, result.stderr
+        assert "reconfigured" in result.stdout.lower()
+
+    def test_boundary_4096_accepted_perl(self, perl_env):
+        """4096 is the maximum and must be accepted in a single attempt."""
+        script_path, workdir, env = perl_env
+        result = self._run_option_1(script_path, env, ["4096"])
+        assert result.returncode == 0, result.stderr
+        assert "reconfigured" in result.stdout.lower()
+
+    def test_boundary_4096_accepted_python(self, python_env):
+        script_path, workdir, env = python_env
+        result = self._run_option_1(script_path, env, ["4096"])
+        assert result.returncode == 0, result.stderr
+        assert "reconfigured" in result.stdout.lower()
+
+    def test_4097_rejected_perl(self, perl_env):
+        """4097 exceeds the limit and must loop back to re-prompt."""
+        script_path, workdir, env = perl_env
+        result = self._run_option_1(script_path, env, ["4097", "2048"])
+        assert result.returncode == 0, result.stderr
+        assert "reconfigured" in result.stdout.lower()
+
+    def test_4097_rejected_python(self, python_env):
+        script_path, workdir, env = python_env
+        result = self._run_option_1(script_path, env, ["4097", "2048"])
+        assert result.returncode == 0, result.stderr
+        assert "reconfigured" in result.stdout.lower()
+
+
+# ---------------------------------------------------------------------------
+# Common name validation  (regex '^[\w\s\-\.]+$')
+# ---------------------------------------------------------------------------
+
+class TestCommonNameValidation:
+
+    def _run_option_2_then_quit(self, script_path, env, cn_inputs):
+        """
+        Enter menu option 2 (create CSR), send CN inputs in sequence,
+        then send 'n' for password protection, then quit.
+        We don't expect a full signing here — just testing CN acceptance.
+        """
+        stdin = "2\n"
+        for cn in cn_inputs:
+            stdin += cn + "\n"
+        # After a valid CN is accepted, the script will try to run openssl.
+        # Send Ctrl-D style by just letting it run; we check returncode/output.
+        stdin += "n\n"   # no password on key
+        stdin += "q\n"
+        return run_script(script_path, stdin, env)
+
+    def test_valid_cn_accepted_perl(self, perl_env):
+        script_path, workdir, env = perl_env
+        result = self._run_option_2_then_quit(script_path, env, ["jdoe"])
+        # Should not loop asking for CN again
+        assert result.stdout.count("Owner [") == 1
+
+    def test_valid_cn_accepted_python(self, python_env):
+        script_path, workdir, env = python_env
+        result = self._run_option_2_then_quit(script_path, env, ["jdoe"])
+        assert result.stdout.count("Owner [") == 1
+
+    def test_invalid_cn_loops_perl(self, perl_env):
+        """A CN with shell-special characters must be rejected and re-prompted."""
+        script_path, workdir, env = perl_env
+        # Send an invalid CN first, then a valid one
+        result = self._run_option_2_then_quit(
+            script_path, env, [";drop tables", "jdoe"])
+        # Prompt should appear at least twice
+        assert result.stdout.count("Owner [") >= 2
+
+    def test_invalid_cn_loops_python(self, python_env):
+        script_path, workdir, env = python_env
+        result = self._run_option_2_then_quit(
+            script_path, env, [";drop tables", "jdoe"])
+        assert result.stdout.count("Owner [") >= 2
+
+    def test_hyphen_dot_cn_accepted_perl(self, perl_env):
+        """Hyphens and dots are valid in a CN (e.g. hostnames)."""
+        script_path, workdir, env = perl_env
+        result = self._run_option_2_then_quit(
+            script_path, env, ["web-server.example.com"])
+        assert result.stdout.count("Owner [") == 1
+
+    def test_hyphen_dot_cn_accepted_python(self, python_env):
+        script_path, workdir, env = python_env
+        result = self._run_option_2_then_quit(
+            script_path, env, ["web-server.example.com"])
+        assert result.stdout.count("Owner [") == 1
+
+
+# ---------------------------------------------------------------------------
+# Serial number regex  (bug: [A-F0-9] missed lowercase hex from modern OpenSSL)
+# ---------------------------------------------------------------------------
+
+class TestSerialRegex:
+    """
+    The revocation code uses a regex to parse serial numbers out of
+    openssl output.  The fix extended it to [A-Fa-f0-9].
+    We verify the regex directly matches lowercase serials.
+    """
+
+    SERIAL_PATTERN = re.compile(r'Serial Number:\s*([A-Fa-f0-9]+)')
+    OLD_PATTERN    = re.compile(r'Serial Number:\s*([A-F0-9]+)')
+
+    @pytest.mark.parametrize("serial", [
+        "01", "ff", "1a2b3c", "ABCDEF", "abcdef", "deadbeef",
+    ])
+    def test_fixed_regex_matches(self, serial):
+        text = f"Serial Number: {serial}"
+        assert self.SERIAL_PATTERN.search(text), \
+            f"Fixed regex should match serial '{serial}'"
+
+    @pytest.mark.parametrize("serial", ["ff", "aabb", "deadbeef", "cafe"])
+    def test_old_regex_misses_lowercase(self, serial):
+        """All-lowercase hex serials must not match the old uppercase-only regex."""
+        text = f"Serial Number: {serial}"
+        assert not self.OLD_PATTERN.search(text), \
+            f"Old uppercase-only regex incorrectly matches lowercase serial '{serial}'"
+
+    def test_old_regex_partial_match_on_mixed(self):
+        """
+        Mixed serials like '1a2b' expose the old bug: the regex captures only
+        the leading digit '1' instead of the full serial, causing revocation
+        verification to silently fail (hex('1') != hex('1a2b')).
+        """
+        text = "Serial Number: 1a2b"
+        m = self.OLD_PATTERN.search(text)
+        full_match = m and m.group(1) == "1a2b"
+        assert not full_match, "Old regex must not capture the full mixed serial"
+
+        new_m = self.SERIAL_PATTERN.search(text)
+        assert new_m and new_m.group(1) == "1a2b", \
+            "Fixed regex must capture the full mixed serial"


### PR DESCRIPTION
## Summary

- **47 tests across 2 files** covering all major ssl-admin workflows for both the Perl and Python implementations
- **`tests/test_parity.py`** — 24 behavioral tests that run identical input sequences through both scripts and assert the same filesystem state results (cert files, CRL, revoked directory, etc.)
- **`tests/test_validation.py`** — 23 tests targeting specific bug fixes: key size numeric vs string comparison, CN regex validation, and serial number hex parsing for lowercase OpenSSL output
- **`tests/openssl_wrapper.py`** — thin OpenSSL wrapper that expands `$ENV::VAR` tokens in config files before invoking the real binary; required because LibreSSL 3.3 (macOS default) does not support `$ENV::` expansion
- **`tests/conftest.py`** — shared pytest fixtures that build isolated CA environments, build test copies of both scripts with placeholder substitution, and manage the wrapper PATH

## Bugs found during test development

- **`openssl.conf [v3_req]`**: `authorityKeyIdentifier` was incorrectly present — LibreSSL correctly rejects AKI in a CSR request (issuer is not yet known at request time)
- **`python/ssl-admin sign_csr()/sign_server()`**: `shutil.move` raises in Python 3.9 when the destination file already exists (unlike Unix `mv`); fixed by unlinking the existing key before moving — matters on re-sign/renew workflows

## Test plan

```
python3 -m pytest tests/ -v
```

All 47 tests pass on macOS with LibreSSL 3.3.6 and Python 3.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)